### PR TITLE
chore(deps): drop legacy providers interface ; closes #16

### DIFF
--- a/qlearnkit/algorithms/qkmeans/qkmeans.py
+++ b/qlearnkit/algorithms/qkmeans/qkmeans.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Union, Optional
 
 from qiskit import QuantumCircuit
 from qiskit.result import Result
-from qiskit.providers import BaseBackend, Backend
+from qiskit.providers import Backend
 from qiskit.tools import parallel_map
 from qiskit.utils import QuantumInstance
 
@@ -86,7 +86,7 @@ class QKMeans(ClusterMixin, QuantumEstimator):
     def __init__(
         self,
         n_clusters: int = 6,
-        quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None,
+        quantum_instance: Optional[Union[QuantumInstance, Backend]] = None,
         *,
         init: Union[str, np.ndarray] = "kmeans++",
         n_init: int = 1,

--- a/qlearnkit/algorithms/qknn/qknn_base.py
+++ b/qlearnkit/algorithms/qknn/qknn_base.py
@@ -6,7 +6,7 @@ import numpy as np
 import logging
 
 from qiskit import QuantumCircuit
-from qiskit.providers import BaseBackend, Backend
+from qiskit.providers import Backend
 from qiskit.result import Result
 from qiskit.tools import parallel_map
 from qiskit.utils import QuantumInstance
@@ -22,7 +22,7 @@ class QNeighborsBase(QuantumEstimator, ABC):
     def __init__(self,
                  n_neighbors: int = 3,
                  encoding_map: Optional[EncodingMap] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None):
+                 quantum_instance: Optional[Union[QuantumInstance, Backend]] = None):
         """
         Base class for Nearest Neighbors algorithms
 

--- a/qlearnkit/algorithms/qknn/qknn_classifier.py
+++ b/qlearnkit/algorithms/qknn/qknn_classifier.py
@@ -3,7 +3,7 @@ from sklearn.exceptions import NotFittedError
 import logging
 import numpy as np
 
-from qiskit.providers import BaseBackend, Backend
+from qiskit.providers import Backend
 from qiskit.utils import QuantumInstance
 
 from typing import Optional, Union
@@ -72,7 +72,7 @@ class QKNeighborsClassifier(ClassifierMixin, QNeighborsBase):
     def __init__(self,
                  n_neighbors: int = 3,
                  encoding_map: Optional[EncodingMap] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None):
+                 quantum_instance: Optional[Union[QuantumInstance, Backend]] = None):
         """
         Creates a QKNeighborsClassifier Object
 

--- a/qlearnkit/algorithms/qknn/qknn_regressor.py
+++ b/qlearnkit/algorithms/qknn/qknn_regressor.py
@@ -3,7 +3,7 @@ from sklearn.exceptions import NotFittedError
 import logging
 import numpy as np
 
-from qiskit.providers import BaseBackend, Backend
+from qiskit.providers import Backend
 from qiskit.utils import QuantumInstance
 
 from typing import Optional, Union
@@ -26,7 +26,7 @@ class QKNeighborsRegressor(RegressorMixin, QNeighborsBase):
     def __init__(self,
                  n_neighbors: int = 3,
                  encoding_map: Optional[EncodingMap] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None):
+                 quantum_instance: Optional[Union[QuantumInstance, Backend]] = None):
         """
         Creates a QKNeighborsClassifier Object
 

--- a/qlearnkit/algorithms/qridge/qridge.py
+++ b/qlearnkit/algorithms/qridge/qridge.py
@@ -5,7 +5,7 @@ import numpy as np
 from sklearn.base import RegressorMixin
 from sklearn.exceptions import NotFittedError
 from qiskit.utils import QuantumInstance
-from qiskit.providers import BaseBackend, Backend
+from qiskit.providers import Backend
 from qiskit.circuit.library import NLocal, ZZFeatureMap
 from ..quantum_estimator import QuantumEstimator
 from ..kernel_method_mixin import KernelMethodMixin
@@ -68,7 +68,7 @@ class QRidgeRegressor(KernelMethodMixin, RegressorMixin, QuantumEstimator):
 
     def __init__(self,
                  encoding_map: Optional[NLocal] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None,
+                 quantum_instance: Optional[Union[QuantumInstance, Backend]] = None,
                  gamma: float = 1.0):
         """
         Creates a Quantum Ridge Regressor

--- a/qlearnkit/algorithms/qsvm/qsvc.py
+++ b/qlearnkit/algorithms/qsvm/qsvc.py
@@ -4,7 +4,7 @@ import numpy as np
 from sklearn.base import ClassifierMixin
 from sklearn.exceptions import NotFittedError
 from qiskit.utils import QuantumInstance
-from qiskit.providers import BaseBackend, Backend
+from qiskit.providers import Backend
 from qiskit.circuit.library import NLocal, ZZFeatureMap
 from ..quantum_estimator import QuantumEstimator
 from ..kernel_method_mixin import KernelMethodMixin
@@ -66,7 +66,7 @@ class QSVClassifier(KernelMethodMixin, ClassifierMixin, QuantumEstimator):
 
     def __init__(self,
                  encoding_map: Optional[NLocal] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None,
+                 quantum_instance: Optional[Union[QuantumInstance, Backend]] = None,
                  gamma: Union[float, str] = 'scale'):
         """
         Creates a Quantum Support Vector Classifier

--- a/qlearnkit/algorithms/quantum_estimator.py
+++ b/qlearnkit/algorithms/quantum_estimator.py
@@ -4,7 +4,7 @@ from typing import Union, Optional, List
 import numpy as np
 from abc import abstractmethod
 from qiskit import QuantumCircuit
-from qiskit.providers import BaseBackend, Backend
+from qiskit.providers import Backend
 from qiskit.result import Result
 from sklearn.base import TransformerMixin
 from qiskit.utils import QuantumInstance
@@ -17,7 +17,7 @@ class QuantumEstimator(TransformerMixin):
     def __init__(
         self,
         encoding_map=None,
-        quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None,
+        quantum_instance: Optional[Union[QuantumInstance, Backend]] = None,
     ):
         """
         Args:
@@ -71,13 +71,13 @@ class QuantumEstimator(TransformerMixin):
 
     @quantum_instance.setter
     def quantum_instance(
-        self, quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]]
+        self, quantum_instance: Optional[Union[QuantumInstance, Backend]]
     ):
         """Quantum Instance setter"""
         self._set_quantum_instance(quantum_instance)
 
     def _set_quantum_instance(
-        self, quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]]
+        self, quantum_instance: Optional[Union[QuantumInstance, Backend]]
     ):
         """
         Internal method to set a quantum instance according to its type
@@ -88,7 +88,7 @@ class QuantumEstimator(TransformerMixin):
             or a :class:`~qiskit.providers.BaseBackend`
 
         """
-        if isinstance(quantum_instance, (BaseBackend, Backend)):
+        if isinstance(quantum_instance, Backend):
             quantum_instance = QuantumInstance(quantum_instance)
 
         self._quantum_instance = quantum_instance

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 qiskit-aer>=0.10.3
-qiskit-terra==0.20.0
+qiskit-terra>=0.20.0
 qiskit-machine-learning>=0.3.1
 scikit-learn==1.0.2
 scipy==1.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra==0.20.0
+qiskit-terra>=0.20.0
 qiskit-aer>=0.10.3
 qiskit-machine-learning>=0.3.1
 scikit-learn==1.0.2


### PR DESCRIPTION
Remove `BaseBackend` instances, deprecated after qiskit-terra 0.20.0.