### PR TITLE
Removing `qiskit-terra` dependency in favor of `qiskit`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-qiskit-terra==0.22.0
+qiskit==0.39
 qiskit-machine-learning==0.4.0
 scikit-learn>=1.0.2
 scipy>=1.10
 numpy<1.24
-


### PR DESCRIPTION
`qlearnkit` depends on `qiskit-terra (>=0.20.0)` https://www.wheelodex.org/projects/qlearnkit/ which is reaching EoL:

> [!IMPORTANT]
> **The package `qiskit-terra` is not going to be updated after August 15th, 2024**. Since Qiskit 0.44 (released on July 27th, 2023), the `qiskit` meta-package only contains `qiskit-terra`. In Qiskit 1.0 and beyond, the meta-package architecture is removed.
> If you are installing or depending on `qiskit-terra`, consider changing that to `qiskit`: Either `qiskit>=0.x,<1` (if you did not transition to Qiskit 1.0 yet) or `qiskit>=0.x,<2` (to also include Qiskit 1.*).
> [Read more](https://docs.quantum.ibm.com/api/migration-guides/qiskit-1.0-installation#the-old-qiskit-structure).
